### PR TITLE
2.6 spinner

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Install
     $ pip install blindspin
 
 
-Supports Python 2.7 and 3.
+Supports Python 2.6, 2.7, and 3.
 
 Based on the work of:
 ---------------------

--- a/blindspin/__init__.py
+++ b/blindspin/__init__.py
@@ -68,8 +68,3 @@ def spinner(beep=False, force=False):
 
     """
     return Spinner(beep, force)
-
-
-from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions

--- a/blindspin/__init__.py
+++ b/blindspin/__init__.py
@@ -28,7 +28,10 @@ class Spinner(object):
 
     def init_spin(self):
         while not self.stop_running.is_set():
-            sys.stdout.write(next(self.spinner_cycle))
+            next_val = next(self.spinner_cycle)
+            if sys.version_info[0] == 2:
+                next_val = next_val.encode('utf-8')
+            sys.stdout.write(next_val)
             sys.stdout.flush()
             time.sleep(0.07)
             sys.stdout.write('\b')


### PR DESCRIPTION
A couple things in here. It looks like the _version module was removed in the last commit but there were still references to it in `__init__.py` causing import errors. I cleaned those up, then added manual encoding for python 2.x to fix 2.6 and updated README.