### PR TITLE
Clean out the spinner character when stopped. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - '2.7'
 - '3.4'
 - '3.5'
+- '3.6'
 notifications:
   email:
   - yoav@yoavram.com

--- a/click_spinner/__init__.py
+++ b/click_spinner/__init__.py
@@ -30,6 +30,7 @@ class Spinner(object):
             sys.stdout.flush()
             time.sleep(0.25)
             sys.stdout.write('\b')
+            sys.stdout.flush()
 
     def __enter__(self):
         self.start()


### PR DESCRIPTION
This removes the unsightly artifacts during the locking operation of pipenv. See below for an example:

Pipfile.lock out of date, updating...
Locking [dev-packages] dependencies...
⠸Locking [packages] dependencies...
⠴Updated Pipfile.lock!
Installing dependencies from Pipfile.lock...