### PR TITLE
Update setup.py to prevent UnicodeDecodeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 from setuptools import setup
 
-with open('README.rst') as f:
+with open('README.rst', encoding="utf8") as f:
     readme = f.read()
 
 


### PR DESCRIPTION
Use "utf8" encoding to open "README.rst" to prevent UnicodeDecodeError below.
UnicodeDecodeError: 'cp950' codec can't decode byte 0xe2 in position 189: illegal multibyte sequence